### PR TITLE
bug fix: assertsEqual incorrect parameters

### DIFF
--- a/src/test/java/Tester.java
+++ b/src/test/java/Tester.java
@@ -19,7 +19,7 @@ public class Tester {
       int result = temp.limitAmplitude(2000);
       //answer [40, 2000, 17, -2000, -17, -2000, 2000]
       String failMsg = "Failed - Input=" + temp.samples + ", Expected 3, Output = " + result;
-      assertEquals(failMsg, 3, result);
+      assertEquals(3, result, failMsg);
    }
 
    @Test
@@ -29,7 +29,7 @@ public class Tester {
       int result = temp.limitAmplitude(2000);
       //answer {1048, -420, 33, 15, -32, 2000, 2000};
       String failMsg = "Failed - Input=" + temp.samples + ", Expected 2, Output = " + result;
-      assertEquals(failMsg, 2, result);
+      assertEquals(2, result, failMsg);
    }
 
    @Test
@@ -40,7 +40,7 @@ public class Tester {
       int result = temp.limitAmplitude(0);
       //answer [40, 2000, 17, -2000, -17, -2000, 2000]
       String failMsg = "Failed - Input=" + temp.samples + ", Expected 7, Output = " + result;
-      assertEquals(failMsg, 7, result);
+      assertEquals(7, result, failMsg);
    }
 
    @Test
@@ -51,7 +51,7 @@ public class Tester {
       int result = temp.limitAmplitude(1);
       //answer [40, 2000, 17, -2000, -17, -2000, 2000]
       String failMsg = "Failed - Input=" + temp.samples + ", Expected 0, Output = " + result;
-      assertEquals(failMsg, 0, result);
+      assertEquals(0, result, failMsg);
       //Failed - Input {} limitAmplitude(1) Expected Output 0
    }
 


### PR DESCRIPTION
assertsEquals was originally incorrectly called as assertsEquals(failmessage, expected, actual); This is inline with the documentation for Junit 4, but Junit 5 changed stuff

In the Junit 5 documentation linked here: https://junit.org/junit5/docs/5.0.1/api/org/junit/jupiter/api/Assertions.html#assertEquals-byte-byte-java.lang.String-

the correct implementation for assertsEqual is 	assertEquals(byte expected, byte actual, String message)

This bug fix will attempt to fix the tester, and I deeply apologize if I am overstepping my bounds as a student and incorrectly point this out

after 20 failed workflow runs, I decided to copy and paste the answer from collegeboard to see if I was really just that bad, but the tester said the answer was wrong which led me to attempt to fix the tester (if it's wrong). my code is commented out to show authenticity as best as I can that this is not a quick copy and paste from college board and to show that the debug workflow run (college board answer) was marked as wrong. thank you, and I am sorry again if I am wrong.